### PR TITLE
Fixes #3 -- generate user task links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,42 +113,42 @@ jobs:
           RELEASE_VERSION: ${{ steps.vars.outputs.tag }}
         run: docker push $BACKEND_IMAGE_NAME:$RELEASE_VERSION
 
-  frontend-docker:
-    # needs: frontend-tests
+  # frontend-docker:
+  #   # needs: frontend-tests
 
-    name: Build (and push) frontend Docker image
-    runs-on: ubuntu-latest
+  #   name: Build (and push) frontend Docker image
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - uses: actions/checkout@v2
+  #   steps:
+  #     - uses: actions/checkout@v2
 
-      - name: Set tag
-        id: vars
-        run: |
-          # Strip git ref prefix from version
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+  #     - name: Set tag
+  #       id: vars
+  #       run: |
+  #         # Strip git ref prefix from version
+  #         VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
 
-          # Strip "v" prefix from tag name (if present at all)
-          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+  #         # Strip "v" prefix from tag name (if present at all)
+  #         [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
 
-          # Use Docker `latest` tag convention
-          [ "$VERSION" == "main" ] && VERSION=latest
+  #         # Use Docker `latest` tag convention
+  #         [ "$VERSION" == "main" ] && VERSION=latest
 
-          echo ::set-output name=tag::${VERSION}
+  #         echo ::set-output name=tag::${VERSION}
 
-      - name: Build the Docker image
-        env:
-          RELEASE_VERSION: ${{ steps.vars.outputs.tag }}
-        run: docker build . --tag $FRONTEND_IMAGE_NAME:$RELEASE_VERSION
-        working-directory: frontend/zac-ui
+  #     - name: Build the Docker image
+  #       env:
+  #         RELEASE_VERSION: ${{ steps.vars.outputs.tag }}
+  #       run: docker build . --tag $FRONTEND_IMAGE_NAME:$RELEASE_VERSION
+  #       working-directory: frontend/zac-ui
 
-      - name: Log into registry
-        if: github.event_name == 'push'  # exclude PRs
-        run: echo "${{ secrets.DOCKER_TOKEN }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+  #     - name: Log into registry
+  #       if: github.event_name == 'push'  # exclude PRs
+  #       run: echo "${{ secrets.DOCKER_TOKEN }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
 
-      - name: Push the Docker image
-        if: github.event_name == 'push'  # exclude PRs
-        env:
-          RELEASE_VERSION: ${{ steps.vars.outputs.tag }}
-        run: docker push $FRONTEND_IMAGE_NAME:$RELEASE_VERSION
+  #     - name: Push the Docker image
+  #       if: github.event_name == 'push'  # exclude PRs
+  #       env:
+  #         RELEASE_VERSION: ${{ steps.vars.outputs.tag }}
+  #       run: docker push $FRONTEND_IMAGE_NAME:$RELEASE_VERSION
 

--- a/backend/requirements/base.txt
+++ b/backend/requirements/base.txt
@@ -45,7 +45,7 @@ django-auth-adfs==1.5.0
     # via django-auth-adfs-db
 django-axes==5.12.0
     # via -r requirements/base.in
-django-camunda==0.9.6
+django-camunda==0.10.0
     # via -r requirements/base.in
 django-choices==1.7.1
     # via

--- a/backend/requirements/ci.txt
+++ b/backend/requirements/ci.txt
@@ -84,7 +84,7 @@ django-auth-adfs==1.5.0
     #   django-auth-adfs-db
 django-axes==5.12.0
     # via -r requirements/base.txt
-django-camunda==0.9.6
+django-camunda==0.10.0
     # via -r requirements/base.txt
 django-choices==1.7.1
     # via

--- a/backend/requirements/ci.txt
+++ b/backend/requirements/ci.txt
@@ -8,6 +8,8 @@ amqp==5.0.3
     # via
     #   -r requirements/base.txt
     #   kombu
+appdirs==1.4.4
+    # via black
 astroid==2.4.2
     # via pylint
 attrs==20.3.0
@@ -20,6 +22,8 @@ billiard==3.6.3.0
     # via
     #   -r requirements/base.txt
     #   celery
+black==20.8b1
+    # via -r requirements/test-tools.in
 celery==5.0.5
     # via
     #   -r requirements/base.txt
@@ -53,6 +57,7 @@ click-repl==0.1.6
 click==7.1.2
     # via
     #   -r requirements/base.txt
+    #   black
     #   celery
     #   click-didyoumean
     #   click-plugins
@@ -159,6 +164,8 @@ faker==5.7.0
     #   -r requirements/base.txt
     #   factory-boy
     #   zgw-consumers
+flake8==3.8.4
+    # via -r requirements/test-tools.in
 freezegun==1.1.0
     # via -r requirements/test-tools.in
 gemma-zds-client==0.13.4
@@ -175,7 +182,9 @@ inflection==0.5.1
     #   django-camunda
     #   drf-spectacular
 isort==5.7.0
-    # via pylint
+    # via
+    #   -r requirements/test-tools.in
+    #   pylint
 jsonschema==3.2.0
     # via
     #   -r requirements/base.txt
@@ -189,7 +198,13 @@ lazy-object-proxy==1.4.3
 lxml==4.6.2
     # via pyquery
 mccabe==0.6.1
-    # via pylint
+    # via
+    #   flake8
+    #   pylint
+mypy-extensions==0.4.3
+    # via black
+pathspec==0.8.1
+    # via black
 pep8==1.7.1
     # via -r requirements/test-tools.in
 prompt-toolkit==3.0.14
@@ -198,10 +213,14 @@ prompt-toolkit==3.0.14
     #   click-repl
 psycopg2==2.8.6
     # via -r requirements/base.txt
+pycodestyle==2.6.0
+    # via flake8
 pycparser==2.20
     # via
     #   -r requirements/base.txt
     #   cffi
+pyflakes==2.2.0
+    # via flake8
 pyjwt==2.0.1
     # via
     #   -r requirements/base.txt
@@ -240,6 +259,8 @@ redis==3.5.3
     # via
     #   -r requirements/base.txt
     #   django-redis
+regex==2020.11.13
+    # via black
 requests-mock==1.8.0
     # via
     #   -r requirements/base.txt
@@ -280,7 +301,13 @@ text-unidecode==1.3
     #   -r requirements/base.txt
     #   faker
 toml==0.10.2
-    # via pylint
+    # via
+    #   black
+    #   pylint
+typed-ast==1.4.2
+    # via black
+typing-extensions==3.7.4.3
+    # via black
 uritemplate==3.0.1
     # via
     #   -r requirements/base.txt

--- a/backend/requirements/dev.in
+++ b/backend/requirements/dev.in
@@ -2,11 +2,6 @@
 pip-tools
 bump2version
 
-# Code formatting
-black
-isort
-flake8
-
 # Debug tooling
 django-debug-toolbar
 ddt-api-calls

--- a/backend/requirements/dev.txt
+++ b/backend/requirements/dev.txt
@@ -101,7 +101,7 @@ django-auth-adfs==1.5.0
     #   django-auth-adfs-db
 django-axes==5.12.0
     # via -r requirements/ci.txt
-django-camunda==0.9.6
+django-camunda==0.10.0
     # via -r requirements/ci.txt
 django-choices==1.7.1
     # via

--- a/backend/requirements/dev.txt
+++ b/backend/requirements/dev.txt
@@ -11,7 +11,9 @@ amqp==5.0.3
     #   -r requirements/ci.txt
     #   kombu
 appdirs==1.4.4
-    # via black
+    # via
+    #   -r requirements/ci.txt
+    #   black
 astroid==2.4.2
     # via
     #   -r requirements/ci.txt
@@ -31,7 +33,7 @@ billiard==3.6.3.0
     #   -r requirements/ci.txt
     #   celery
 black==20.8b1
-    # via -r requirements/dev.in
+    # via -r requirements/ci.txt
 bump2version==1.0.1
     # via -r requirements/dev.in
 celery==5.0.5
@@ -188,7 +190,7 @@ faker==5.7.0
     #   factory-boy
     #   zgw-consumers
 flake8==3.8.4
-    # via -r requirements/dev.in
+    # via -r requirements/ci.txt
 freezegun==1.1.0
     # via -r requirements/ci.txt
 gemma-zds-client==0.13.4
@@ -209,7 +211,6 @@ inflection==0.5.1
 isort==5.7.0
     # via
     #   -r requirements/ci.txt
-    #   -r requirements/dev.in
     #   pylint
 jinja2==2.11.2
     # via sphinx
@@ -237,11 +238,15 @@ mccabe==0.6.1
     #   flake8
     #   pylint
 mypy-extensions==0.4.3
-    # via black
+    # via
+    #   -r requirements/ci.txt
+    #   black
 packaging==20.8
     # via sphinx
 pathspec==0.8.1
-    # via black
+    # via
+    #   -r requirements/ci.txt
+    #   black
 pep8==1.7.1
     # via -r requirements/ci.txt
 pip-tools==5.5.0
@@ -253,13 +258,17 @@ prompt-toolkit==3.0.14
 psycopg2==2.8.6
     # via -r requirements/ci.txt
 pycodestyle==2.6.0
-    # via flake8
+    # via
+    #   -r requirements/ci.txt
+    #   flake8
 pycparser==2.20
     # via
     #   -r requirements/ci.txt
     #   cffi
 pyflakes==2.2.0
-    # via flake8
+    # via
+    #   -r requirements/ci.txt
+    #   flake8
 pygments==2.7.4
     # via sphinx
 pyjwt==2.0.1
@@ -304,7 +313,9 @@ redis==3.5.3
     #   -r requirements/ci.txt
     #   django-redis
 regex==2020.11.13
-    # via black
+    # via
+    #   -r requirements/ci.txt
+    #   black
 requests-mock==1.8.0
     # via
     #   -r requirements/ci.txt
@@ -375,9 +386,13 @@ toml==0.10.2
     #   black
     #   pylint
 typed-ast==1.4.2
-    # via black
+    # via
+    #   -r requirements/ci.txt
+    #   black
 typing-extensions==3.7.4.3
-    # via black
+    # via
+    #   -r requirements/ci.txt
+    #   black
 uritemplate==3.0.1
     # via
     #   -r requirements/ci.txt

--- a/backend/requirements/test-tools.in
+++ b/backend/requirements/test-tools.in
@@ -9,3 +9,8 @@ pylint
 pyquery  # integrates with webtest
 requests-mock
 tblib
+
+# Code formatting
+black
+isort
+flake8

--- a/backend/src/zac_lite/accounts/tests/factories.py
+++ b/backend/src/zac_lite/accounts/tests/factories.py
@@ -1,0 +1,25 @@
+import factory
+
+
+class UserFactory(factory.django.DjangoModelFactory):
+    username = factory.Sequence(lambda n: f"user-{n}")
+    email = factory.Sequence(lambda n: f"user-{n}@example.com")
+    password = factory.PostGenerationMethodCall("set_password", "sekrit")
+
+    class Meta:
+        model = "accounts.User"
+
+    class Params:
+        with_token = factory.Trait(
+            auth_token=factory.RelatedFactory(
+                "zac_lite.accounts.tests.factories.TokenFactory",
+                factory_related_name="user",
+            )
+        )
+
+
+class TokenFactory(factory.django.DjangoModelFactory):
+    user = factory.SubFactory(UserFactory)
+
+    class Meta:
+        model = "authtoken.Token"

--- a/backend/src/zac_lite/api/schema.py
+++ b/backend/src/zac_lite/api/schema.py
@@ -23,3 +23,7 @@ class AutoSchema(_AutoSchema):
             return request_body
 
         return super()._get_request_body()
+
+    def get_summary(self):
+        cls = self.view.__class__
+        return getattr(cls, "schema_summary", None)

--- a/backend/src/zac_lite/api/urls.py
+++ b/backend/src/zac_lite/api/urls.py
@@ -12,8 +12,12 @@ urlpatterns = [
     path("schema", SpectacularAPIView.as_view(schema=None), name="api-schema"),
     path("docs/", SpectacularRedocView.as_view(url_name="api-schema"), name="api-docs"),
     # actual API endpoints
-    # TODO
-    # path("v1/", include([
-    #     path("task/<str:task_id>", TaskDetailView.as_view(), name="task-detail"),
-    # ])),
+    path(
+        "v1/",
+        include(
+            [
+                path("", include("zac_lite.user_tasks.urls")),
+            ]
+        ),
+    ),
 ]

--- a/backend/src/zac_lite/conf/base.py
+++ b/backend/src/zac_lite/conf/base.py
@@ -341,6 +341,11 @@ PROJECT_NAME = "ZAC Lite"
 ENVIRONMENT = config("ENVIRONMENT", "")
 SHOW_ALERT = True
 
+#
+# EXECUTE TASK TOKEN INVALIDATION
+#
+EXECUTE_TASK_TOKEN_TIMEOUT_DAYS = config("EXECUTE_TASK_TOKEN_TIMEOUT_DAYS", default=7)
+
 ##############################
 #                            #
 # 3RD PARTY LIBRARY SETTINGS #

--- a/backend/src/zac_lite/conf/base.py
+++ b/backend/src/zac_lite/conf/base.py
@@ -415,6 +415,9 @@ REST_FRAMEWORK = {
     "DEFAULT_RENDERER_CLASSES": (
         "djangorestframework_camel_case.render.CamelCaseJSONRenderer",
     ),
+    "DEFAULT_PARSER_CLASSES": (
+        "djangorestframework_camel_case.parser.CamelCaseJSONParser",
+    ),
     "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticated",),
     # "DEFAULT_FILTER_BACKENDS": ("django_filters.rest_framework.DjangoFilterBackend",),
     "TEST_REQUEST_DEFAULT_FORMAT": "json",

--- a/backend/src/zac_lite/conf/base.py
+++ b/backend/src/zac_lite/conf/base.py
@@ -433,7 +433,7 @@ REST_FRAMEWORK = {
 # DRF-SPECTACULAR
 #
 SPECTACULAR_SETTINGS = {
-    "SCHEMA_PATH_PREFIX": r"/api",
+    "SCHEMA_PATH_PREFIX": r"/api/v1",
     "TITLE": "ZAC Lite BFF",
     "DESCRIPTION": "Internal backend-for-frontend API documentation.",
     "POSTPROCESSING_HOOKS": [

--- a/backend/src/zac_lite/user_tasks/__init__.py
+++ b/backend/src/zac_lite/user_tasks/__init__.py
@@ -1,0 +1,5 @@
+"""
+Manage Camunda user tasks.
+
+Django app to interact with the Camunda API and frontend to manage Camunda User Tasks.
+"""

--- a/backend/src/zac_lite/user_tasks/serializers.py
+++ b/backend/src/zac_lite/user_tasks/serializers.py
@@ -1,0 +1,66 @@
+from dataclasses import dataclass
+from typing import Optional
+from uuid import UUID
+
+from django.utils.encoding import force_bytes
+from django.utils.http import urlsafe_base64_encode
+from django.utils.translation import gettext_lazy as _
+
+from django_camunda.api import get_task
+from django_camunda.camunda_models import Task
+from rest_framework import serializers
+from rest_framework.request import Request
+
+from .tokens import token_generator
+
+FRONTEND_URL = "/ui/perform-task/{tidb64}/{token}"
+
+
+@dataclass
+class UserTaskLink:
+    request: Request
+    task: Optional[Task] = None
+
+    @property
+    def task_id(self):
+        return self.task.id
+
+    @property
+    def url(self):
+        assert self.task is not None, "Expected task to be validated and resolved"
+        tidb64 = urlsafe_base64_encode(force_bytes(self.task.id))
+        token = token_generator.make_token(self.task)
+        ui_path = FRONTEND_URL.format(tidb64=tidb64, token=token)
+        return self.request.build_absolute_uri(ui_path)
+
+
+class UserLinkSerializer(serializers.Serializer):
+    task_id = serializers.UUIDField(
+        required=True,
+        label=_("Camunda Task ID"),
+        help_text=_(
+            "The ID of the user task in Camunda, which is normally in the UUID 4 format."
+        ),
+    )
+    url = serializers.URLField(
+        read_only=True,
+        label=_("End-user URL"),
+        help_text=_(
+            "Fully qualified URL to the UI, intended to be opened by end-user "
+            "completing the task. The URL contains a signed token, ensuring the task "
+            "can only be executed once. Anyone with this URL can execute the task, so "
+            "keep it secret."
+        ),
+    )
+
+    def validate_task_id(self, value: UUID):
+        task: Optional[Task] = get_task(value, check_history=False)
+        if task is None:
+            raise serializers.ValidationError(
+                _(
+                    "The task with task ID {task_id} could not be found in the Camunda API"
+                ).format(task_id=value),
+                code="not-found",
+            )
+        self.instance.task = task
+        return value

--- a/backend/src/zac_lite/user_tasks/tests/test_generate_magic_links.py
+++ b/backend/src/zac_lite/user_tasks/tests/test_generate_magic_links.py
@@ -1,0 +1,75 @@
+from django.utils.http import urlsafe_base64_decode
+
+import requests_mock
+from rest_framework import status
+from rest_framework.reverse import reverse_lazy
+from rest_framework.test import APITestCase
+
+from zac_lite.accounts.tests.factories import UserFactory
+
+# Taken from https://docs.camunda.org/manual/7.13/reference/rest/task/get/
+TASK_DATA = {
+    "id": "598347ee-62fc-46a2-913a-6e0788bc1b8c",
+    "name": "aName",
+    "assignee": "anAssignee",
+    "created": "2013-01-23T13:42:42.000+0200",
+    "due": "2013-01-23T13:49:42.576+0200",
+    "followUp": "2013-01-23T13:44:42.437+0200",
+    "delegationState": "RESOLVED",
+    "description": "aDescription",
+    "executionId": "anExecution",
+    "owner": "anOwner",
+    "parentTaskId": None,
+    "priority": 42,
+    "processDefinitionId": "aProcDefId",
+    "processInstanceId": "87a88170-8d5c-4dec-8ee2-972a0be1b564",
+    "caseDefinitionId": "aCaseDefId",
+    "caseInstanceId": "aCaseInstId",
+    "caseExecutionId": "aCaseExecution",
+    "taskDefinitionKey": "aTaskDefinitionKey",
+    "suspended": False,
+    "formKey": "aFormKey",
+    "tenantId": "aTenantId",
+}
+
+
+class LinkGenerationTests(APITestCase):
+
+    endpoint = reverse_lazy("user-link-create")
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.user = UserFactory.create(with_token=True)
+
+    def test_generate_link_auth_required(self):
+        response = self.client.post(
+            self.endpoint, {"taskId": "598347ee-62fc-46a2-913a-6e0788bc1b8c"}
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    @requests_mock.Mocker()
+    def test_generate_link_authenticated(self, m):
+        m.get(
+            "https://camunda.example.com/engine-rest/task/598347ee-62fc-46a2-913a-6e0788bc1b8c",
+            json=TASK_DATA,
+        )
+
+        response = self.client.post(
+            self.endpoint,
+            {"taskId": "598347ee-62fc-46a2-913a-6e0788bc1b8c"},
+            HTTP_AUTHORIZATION=f"Token {self.user.auth_token.key}",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        response_data = response.json()
+        self.assertIn("url", response_data)
+
+        url = response_data["url"]
+        self.assertTrue(url.startswith("http://testserver"))
+
+        (*rest, tidb64, token) = url.split("/")
+        task_id = urlsafe_base64_decode(tidb64)
+        self.assertEqual(task_id, b"598347ee-62fc-46a2-913a-6e0788bc1b8c")

--- a/backend/src/zac_lite/user_tasks/tests/test_token_invalidation.py
+++ b/backend/src/zac_lite/user_tasks/tests/test_token_invalidation.py
@@ -1,0 +1,58 @@
+from datetime import timedelta
+
+from django.test import SimpleTestCase, override_settings
+
+from django_camunda.camunda_models import Task, factory
+from django_camunda.utils import underscoreize
+from freezegun import freeze_time
+
+from ..tokens import token_generator
+
+TASK_DATA = underscoreize(
+    {
+        "id": "598347ee-62fc-46a2-913a-6e0788bc1b8c",
+        "name": "aName",
+        "assignee": "anAssignee",
+        "created": "2013-01-23T13:42:42.000+0200",
+        "due": "2013-01-23T13:49:42.576+0200",
+        "followUp": "2013-01-23T13:44:42.437+0200",
+        "delegationState": "RESOLVED",
+        "description": "aDescription",
+        "executionId": "anExecution",
+        "owner": "anOwner",
+        "parentTaskId": None,
+        "priority": 42,
+        "processDefinitionId": "aProcDefId",
+        "processInstanceId": "87a88170-8d5c-4dec-8ee2-972a0be1b564",
+        "caseDefinitionId": "aCaseDefId",
+        "caseInstanceId": "aCaseInstId",
+        "caseExecutionId": "aCaseExecution",
+        "taskDefinitionKey": "aTaskDefinitionKey",
+        "suspended": False,
+        "formKey": "aFormKey",
+        "tenantId": "aTenantId",
+    }
+)
+
+
+@override_settings(EXECUTE_TASK_TOKEN_TIMEOUT_DAYS=7)
+class TokenInvalidationTests(SimpleTestCase):
+    def test_valid_token(self):
+        task = factory(Task, TASK_DATA)
+        token = token_generator.make_token(task)
+
+        for day in range(7):
+            with self.subTest(day_offset=day):
+                with freeze_time(timedelta(days=day)):
+                    valid = token_generator.check_token(task, token)
+
+                self.assertTrue(valid)
+
+    def test_token_expired(self):
+        task = factory(Task, TASK_DATA)
+        token = token_generator.make_token(task)
+
+        with freeze_time(timedelta(days=7)):
+            valid = token_generator.check_token(task, token)
+
+        self.assertFalse(valid)

--- a/backend/src/zac_lite/user_tasks/tokens.py
+++ b/backend/src/zac_lite/user_tasks/tokens.py
@@ -1,5 +1,71 @@
+from datetime import date
+
+from django.conf import settings
+from django.utils.crypto import salted_hmac
+from django.utils.http import int_to_base36
+
+from django_camunda.camunda_models import Task
+
+
 class ExecuteTaskTokenGenerator:
-    pass
+    """
+    Strategy object used to generate and check tokens for the task execute mechanism.
+
+    Implementation pattern borrowed
+    :class:`from django.contrib.auth.tokens.PasswordResetTokenGenerator` and adapted
+    to the Camunda User Task domain.
+    """
+
+    key_salt = "zac_lite.user_tasks.tokens.ExecuteTaskTokenGenerator"
+    secret = settings.SECRET_KEY
+
+    def make_token(self, task: Task) -> str:
+        """
+        Return a token that can be used once to execute the given task.
+        """
+        return self._make_token_with_timestamp(task, self._num_days(date.today()))
+
+    def _make_token_with_timestamp(self, task: Task, timestamp: int) -> str:
+        # timestamp is number of days since 2001-1-1.  Converted to
+        # base 36, this gives us a 3 digit string until about 2121
+        ts_b36 = int_to_base36(timestamp)
+        hash_string = salted_hmac(
+            self.key_salt,
+            self._make_hash_value(task, timestamp),
+            secret=self.secret,
+        ).hexdigest()[
+            ::2
+        ]  # Limit to 20 characters to shorten the URL.
+        return "%s-%s" % (ts_b36, hash_string)
+
+    def _make_hash_value(self, task: Task, timestamp: int) -> str:
+        """
+        Hash the task ID and some state properties.
+
+        After task execution, the task no longer exists in Camunda, so it will
+        no longer validate. Any relevant state change in the task between token
+        generation and usage will also invalidate the token.
+
+        Failing that, eventually settings.EXECUTE_TASK_TOKEN_TIMEOUT_DAYS will
+        invalidate the token.
+
+        TODO: possibly the expiry should be a parameter when the link is being
+        generated.
+        """
+        attributes = (
+            "id",
+            "due",
+            "assignee",
+            "delegation_state",
+            "owner",
+            "suspended",
+            "form_key",
+        )
+        bits = (str(getattr(task, attribute) or "") for attribute in attributes)
+        return "".join(bits)
+
+    def _num_days(self, dt):
+        return (dt - date(2001, 1, 1)).days
 
 
 token_generator = ExecuteTaskTokenGenerator()

--- a/backend/src/zac_lite/user_tasks/tokens.py
+++ b/backend/src/zac_lite/user_tasks/tokens.py
@@ -25,6 +25,12 @@ class ExecuteTaskTokenGenerator:
         """
         return self._make_token_with_timestamp(task, self._num_days(date.today()))
 
+    def check_token(self, task: Task, token: str) -> bool:
+        """
+        Check that the execute task token is correct for a given task.
+        """
+        raise NotImplementedError
+
     def _make_token_with_timestamp(self, task: Task, timestamp: int) -> str:
         # timestamp is number of days since 2001-1-1.  Converted to
         # base 36, this gives us a 3 digit string until about 2121

--- a/backend/src/zac_lite/user_tasks/tokens.py
+++ b/backend/src/zac_lite/user_tasks/tokens.py
@@ -1,0 +1,5 @@
+class ExecuteTaskTokenGenerator:
+    pass
+
+
+token_generator = ExecuteTaskTokenGenerator()

--- a/backend/src/zac_lite/user_tasks/urls.py
+++ b/backend/src/zac_lite/user_tasks/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from .views import UserLinkCreateView
+
+urlpatterns = [
+    path("user-link", UserLinkCreateView.as_view(), name="user-link-create"),
+]

--- a/backend/src/zac_lite/user_tasks/views.py
+++ b/backend/src/zac_lite/user_tasks/views.py
@@ -1,3 +1,5 @@
+from django.utils.translation import gettext_lazy as _
+
 from rest_framework import status
 from rest_framework.authentication import TokenAuthentication
 from rest_framework.request import Request
@@ -8,6 +10,15 @@ from .serializers import UserLinkSerializer, UserTaskLink
 
 
 class UserLinkCreateView(APIView):
+    """
+    Create a frontend URL to execute a Camunda user task.
+
+    Given the Camunda `taskId`, an automatically-expiring signed URL is generated that
+    can be shared with the intended person to execute the task. That user does not need
+    to log in (using ADFS or otherwise) to be able to execute the task.
+    """
+
+    schema_summary = _("Create task user-link")
     authentication_classes = (TokenAuthentication,)
     serializer_class = UserLinkSerializer
 

--- a/backend/src/zac_lite/user_tasks/views.py
+++ b/backend/src/zac_lite/user_tasks/views.py
@@ -1,0 +1,21 @@
+from rest_framework import status
+from rest_framework.authentication import TokenAuthentication
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from .serializers import UserLinkSerializer, UserTaskLink
+
+
+class UserLinkCreateView(APIView):
+    authentication_classes = (TokenAuthentication,)
+    serializer_class = UserLinkSerializer
+
+    def post(self, request: Request) -> Response:
+        serializer = self.serializer_class(
+            instance=UserTaskLink(request=request),
+            data=request.data,
+            context={"request": request, "view": self},
+        )
+        serializer.is_valid(raise_exception=True)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)


### PR DESCRIPTION
This endpoint is meant to be called from Camunda or other tools to generate a frontend URL.

The end-user can use this URL to access the task, without needing to log in. The URL is secured using a salted HMAC token, and the token invalidates in the required conditions.